### PR TITLE
Remove string annotations from converters

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,9 +3,12 @@ import logging
 import tempfile
 from pathlib import Path
 import pytest
-from pydra import set_input_validator
-
-# set_input_validator(True)
+try:
+    from pydra import set_input_validator
+except ImportError:
+    pass
+else:
+    set_input_validator(True)
 from fileformats.medimage.dicom import DicomDir
 
 

--- a/fileformats/medimage/base.py
+++ b/fileformats/medimage/base.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 from fileformats.generic import FileSet
 
 
@@ -103,4 +104,4 @@ class MedicalImage(FileSet):
         """
         Return the RMS difference between the image arrays
         """
-        return np.sqrt(np.sum((self.get_array() - other_image.get_array()) ** 2))
+        return math.sqrt(sum((self.get_array() - other_image.get_array()) ** 2))

--- a/fileformats/medimage/converters.py
+++ b/fileformats/medimage/converters.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from pathlib import Path
 import attrs
 import json

--- a/fileformats/medimage/converters.py
+++ b/fileformats/medimage/converters.py
@@ -70,7 +70,7 @@ def mrconvert(name, out_ext: str):
 def ensure_dicom_dir(dicom: DicomCollection) -> DicomDir:
     if isinstance(dicom, DicomSet):
         dicom_dir_fspath = tempfile.mkdtemp()
-        dicom.copy_to(dicom_dir_fspath, symlink=True)
+        dicom.copy(dicom_dir_fspath, link_type="symbolic")
         dicom = DicomDir(dicom_dir_fspath)
     elif not isinstance(dicom, DicomDir):
         raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.rst"
 requires-python = ">=3.7"
 dependencies = [
     "fileformats >=0.4.0",
+    "numpy >=1.25.1"
 ]
 license = {file = "LICENSE"}
 authors = [


### PR DESCRIPTION
* removes string annotations from converters, which doesn't play nice with Pydra's typing
* updated copy_to to copy